### PR TITLE
Fix `no default export` issue

### DIFF
--- a/lib/StoryblokComponent.astro
+++ b/lib/StoryblokComponent.astro
@@ -5,4 +5,4 @@
 	const Component = components[blok.component];
 ---
 
-{<Component blok={blok} />}
+<Component blok={blok} />


### PR DESCRIPTION
Fix VS Code's `no default export` issue

closes #11