### PR TITLE
fix: supports blok names that aren't valid JS variable names

### DIFF
--- a/lib/StoryblokComponent.astro
+++ b/lib/StoryblokComponent.astro
@@ -1,8 +1,25 @@
 ---
 import components from "virtual:storyblok-components";
+import camelcase from "camelcase";
+
 const { blok, ...props } = Astro.props;
 
-const Component = components[blok.component];
+/**
+ * convert blok components to camel case to match vite-plugin-storyblok
+ */
+const key = camelcase(blok.component);
+
+if (!(key in components)) {
+  /**
+   * Component not found! Log an error with details on the blok name that could not be found
+   * TODO: Add support for a placeholder component as a fallback?
+   */
+  throw new Error(
+    `Component could not be found for blok "${blok.component}"! Is it defined in astro.config.mjs?`
+  );
+}
+
+const Component = components[key];
 ---
 
 <Component blok={blok} {...props} />

--- a/lib/package.json
+++ b/lib/package.json
@@ -27,7 +27,8 @@
     "prepublishOnly": "npm run build && cp ../README.md ./"
   },
   "dependencies": {
-    "@storyblok/js": "^1.8.5"
+    "@storyblok/js": "^1.8.5",
+    "camelcase": "^7.0.0"
   },
   "devDependencies": {
     "@cypress/vite-dev-server": "^2.0.7",

--- a/lib/vite-plugin-storyblok.js
+++ b/lib/vite-plugin-storyblok.js
@@ -1,6 +1,8 @@
 /**
  * Custom Vite plugin by Tony Sull (https://github.com/tony-sull)
  */
+import camelcase from "camelcase";
+
 export function vitePluginStoryblok(components) {
   const virtualModuleId = "virtual:storyblok-components";
   const resolvedVirtualModuleId = "\0" + virtualModuleId;
@@ -17,11 +19,15 @@ export function vitePluginStoryblok(components) {
         const imports = [];
         for await (const [key, value] of Object.entries(components)) {
           const { id } = await this.resolve("/src/" + value + ".astro");
-          imports.push(`import ${key} from "${id}"`);
+          /**
+           * convert blok names to camel case for valid import names
+           * StoryblokComponent.astro needs to do the same when resolving components!
+           */
+          imports.push(`import ${camelcase(key)} from "${id}"`);
         }
-        return `${imports.join(";")};export default {${Object.keys(
-          components
-        ).join(",")}}`;
+        return `${imports.join(";")};export default {${Object.keys(components)
+          .map((key) => camelcase(key))
+          .join(",")}}`;
       }
     },
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,8 @@
       "name": "@storyblok/astro",
       "version": "1.0.0",
       "dependencies": {
-        "@storyblok/js": "^1.8.5"
+        "@storyblok/js": "^1.8.5",
+        "camelcase": "^7.0.0"
       },
       "devDependencies": {
         "@cypress/vite-dev-server": "^2.0.7",
@@ -38,6 +39,17 @@
         "eslint-plugin-cypress": "^2.12.1",
         "start-server-and-test": "^1.14.0",
         "vite": "^3.1.3"
+      }
+    },
+    "lib/node_modules/camelcase": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.0.tgz",
+      "integrity": "sha512-JToIvOmz6nhGsUhAYScbo2d6Py5wojjNfoxoc2mEVLUdJ70gJK2gnd+ABY1Tc3sVMyK7QDPtN0T/XdlCQWITyQ==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "lib/node_modules/esbuild": {
@@ -12844,12 +12856,18 @@
         "@rollup/plugin-dynamic-import-vars": "^1.4.4",
         "@storyblok/js": "^1.8.5",
         "axios": "^0.27.2",
+        "camelcase": "*",
         "cypress": "^10.9.0",
         "eslint-plugin-cypress": "^2.12.1",
         "start-server-and-test": "^1.14.0",
         "vite": "^3.1.3"
       },
       "dependencies": {
+        "camelcase": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.0.tgz",
+          "integrity": "sha512-JToIvOmz6nhGsUhAYScbo2d6Py5wojjNfoxoc2mEVLUdJ70gJK2gnd+ABY1Tc3sVMyK7QDPtN0T/XdlCQWITyQ=="
+        },
         "esbuild": {
           "version": "0.15.9",
           "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.9.tgz",
@@ -13068,7 +13086,7 @@
         "@astrojs/tailwind": "^1.0.0",
         "@astrojs/vue": "^1.0.0",
         "@storyblok/astro": "1.0.0",
-        "astro": "1.4.0",
+        "astro": "^1.4.0",
         "axios": "^0.27.2",
         "react": "^18.2.0",
         "svelte": "^3.50.1",


### PR DESCRIPTION
closes #38 
closes #37 

This adds [camelcase](https://www.npmjs.com/package/camelcase) to safely convert blok names to valid JavaScript variable names.  Ex: `page-custom` will be converted to `pageCustom` internally

This blok name conversion is handled internally in the `vite-plugin-storyblok` and `StoryblokComponent.astro` so it should Just Work:tm: in users' Astro projects 🎉 

**Example error message**

<img width="902" alt="Screen Shot 2022-10-21 at 3 31 47 PM" src="https://user-images.githubusercontent.com/15836226/197283738-1b890f2c-8006-4fa9-924b-89a188358e6b.png">

#### Future work

I marked this as closing #37 *but* there was a really interesting discussion there related to placeholder components when a blok isn't found.  Happy to remove that issue from this PR if the Storyblok team is interested in adding support for placeholder bloks!