### PR TITLE
Tiny type fixes

### DIFF
--- a/lib/StoryblokComponent.astro
+++ b/lib/StoryblokComponent.astro
@@ -5,7 +5,7 @@ import type { SbBlokData } from "./types";
 
 interface Props {
   blok: SbBlokData;
-  props: object;
+  [prop: string]: unknown;
 }
 
 const { blok, ...props } = Astro.props;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,6 +4,7 @@ import { vitePluginStoryblokComponents } from "./vite-plugin-storyblok-component
 import {
   RichTextResolver,
   renderRichText as origRenderRichText,
+  StoryblokClient,
 } from "@storyblok/js";
 
 import type { AstroIntegration } from "astro";
@@ -17,7 +18,7 @@ export {
   RichTextSchema,
 } from "@storyblok/js";
 
-export function useStoryblokApi() {
+export function useStoryblokApi(): StoryblokClient {
   if (!globalThis.storyblokApiInstance) {
     console.error("storyblokApiInstance has not been initialized correctly");
   }


### PR DESCRIPTION
Tiny type fixes:
- `useStoryblokAPI`'s return type was `any`, because of the use of globalThis.
- `StoryblokComponent` was expecting a prop called `props` in all components