### PR TITLE
fix: improve missing component error handling

### DIFF
--- a/lib/vite-plugin-storyblok-components.ts
+++ b/lib/vite-plugin-storyblok-components.ts
@@ -18,12 +18,18 @@ export function vitePluginStoryblokComponents(components?: object) {
       if (id === resolvedVirtualModuleId) {
         const imports = [];
         for await (const [key, value] of Object.entries(components)) {
-          const { id } = await this.resolve("/src/" + value + ".astro");
+          const resolvedId = await this.resolve("/src/" + value + ".astro");
+
+          if (!resolvedId) {
+            throw new Error(
+              `Component could not be found for blok "${key}"! Does "/src/${value}.astro" exist?`
+            );
+          }
           /**
            * convert blok names to camel case for valid import names
            * StoryblokComponent.astro needs to do the same when resolving components!
            */
-          imports.push(`import ${camelcase(key)} from "${id}"`);
+          imports.push(`import ${camelcase(key)} from "${resolvedId.id}"`);
         }
 
         return `${imports.join(";")};export default {${Object.keys(components)


### PR DESCRIPTION
When a component is registered in `astro.config.mjs` but not yet created as a file, a much more meaningful error is thrown now, indicating which file is missing.