### PR TITLE
fix: type declarations not included in package

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -15,7 +15,7 @@
     },
     "./StoryblokComponent.astro": "./StoryblokComponent.astro"
   },
-  "types": "./dist/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "scripts": {
     "dev": "vite build --watch",
     "build": "vite build",

--- a/lib/tsconfig.json
+++ b/lib/tsconfig.json
@@ -7,5 +7,5 @@
   "extends": "astro/tsconfigs/base",
   "$schema": "https://json.schemastore.org/tsconfig",
   "include": ["./*.astro", "./**/*.ts"],
-  "exclude": ["node_modules/*"]
+  "exclude": ["node_modules/*", "./vite-plugin-*.ts"]
 }

--- a/lib/vite.config.ts
+++ b/lib/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig(() => {
     },
     plugins: [
       dts({
+        outputDir: "dist/types",
         skipDiagnostics: false,
       }) as unknown as Plugin,
     ],


### PR DESCRIPTION
Types were correctly generated, but not included in the npm package. Moved to `dist/types` folder. Also excluded Vite plugins from type generation.