### PR TITLE
Feat - Add StoryblokBridge Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ bridge: {
 
 - `customParent` is used to provide a custom URL for the Storyblok editor iframe.
 - `preventClicks` prevents the default behaviour of clicks when inside the Storyblok editor.
-- `resolveRelations` may be needed to tell the Storyblok Bridge to resolve the same relations that are already resolved in the API requests via the `resolve_relations` parameter.
+- `resolveRelations` may be needed to tell the Storyblok Bridge to resolve the same relations that are already resolved in the API requests via the `resolve_relations` parameter. _Note: this paramenter won't have any effect in Astro, since the Storyblok Bridge will reload the page and thus all the requests needed will be performed after the reload_
 
 The provided options will be used to initialize the Storyblok Bridge.
 You can find more information about the Storyblok Bridge and its configuration options on the [In Depth Storyblok Bridge guide](https://www.storyblok.com/docs/guide/in-depth/storyblok-latest-js-v2).

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ import StoryblokComponent from "@storyblok/astro/StoryblokComponent.astro";
 
 export async function getStaticPaths() {
   const storyblokApi = useStoryblokApi();
-  
+
   const { data } = await storyblokApi.get("cdn/links", {
     version: "draft",
   });
@@ -251,6 +251,23 @@ const story = data.story;
 The Storyblok Bridge is enabled by default. If you would like to disable it or enable it conditionally (e.g. depending on the environment) you can set the `bridge` parameter to `true` or `false` in `astro.config.mjs`:
 
 > Note: Since Astro is not a reactive JavaScript framework and renders everything as HTML, the Storyblok Bridge will not provide real-time editing as you may know it from other frameworks. However, it automatically refreshes the site for you whenever you save or publish a story.
+
+You can also provide a `StoryblokBridgeConfigV2` configuration object to the `bridge` parameter.
+
+```
+bridge: {
+  customParent?: string,
+  preventClicks?: boolean, // Defaults to false.
+  resolveRelations?: strings[]
+}
+```
+
+- `customParent` is used to provide a custom URL for the Storyblok editor iframe.
+- `preventClicks` prevents the default behaviour of clicks when inside the Storyblok editor.
+- `resolveRelations` may be needed to tell the Storyblok Bridge to resolve the same relations that are already resolved in the API requests via the `resolve_relations` parameter.
+
+The provided options will be used to initialize the Storyblok Bridge.
+You can find more information about the Storyblok Bridge and its configuration options on the [In Depth Storyblok Bridge guide](https://www.storyblok.com/docs/guide/in-depth/storyblok-latest-js-v2).
 
 If you want to deploy a dedicated preview environment with the Bridge enabled, allowing users of the Storyblok CMS to see their changes being reflected on the frontend directly without having to rebuild the static site, you can enable Server Side Rendering for that particular use case. More information can be found in the [Astro Docs](https://docs.astro.build/en/guides/server-side-rendering/).
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -8,7 +8,12 @@ import {
 } from "@storyblok/js";
 
 import type { AstroIntegration } from "astro";
-import type { ISbConfig, ISbRichtext, SbRichTextOptions } from "./types";
+import {
+  ISbConfig,
+  ISbRichtext,
+  SbRichTextOptions,
+  StoryblokBridgeConfigV2,
+} from "./types";
 
 export {
   storyblokEditable,
@@ -24,7 +29,10 @@ export function useStoryblokApi(): StoryblokClient {
   return globalThis.storyblokApiInstance;
 }
 
-export function renderRichText(data?: ISbRichtext, options?: SbRichTextOptions) {
+export function renderRichText(
+  data?: ISbRichtext,
+  options?: SbRichTextOptions
+) {
   const resolverInstance: RichTextResolver =
     globalThis.storyblokApiInstance.richTextResolver;
   if (!resolverInstance) {
@@ -50,9 +58,9 @@ export type IntegrationOptions = {
    */
   apiOptions?: ISbConfig;
   /**
-   * A boolean to enable/disable the Storyblok JavaScript Bridge. Enabled by default.
+   * A boolean to enable/disable the Storyblok JavaScript Bridge or a StoryblokBridgeConfigV2 configuration object. Enabled by default.
    */
-  bridge?: boolean;
+  bridge?: boolean | StoryblokBridgeConfigV2;
   /**
    * An object containing your Astro components to their Storyblok equivalents.
    * Example:
@@ -123,13 +131,17 @@ export default function storyblokIntegration(
         );
 
         if (resolvedOptions.bridge) {
+          const bridgeConfigurationOptions = { ...resolvedOptions.bridge };
+
           injectScript(
             "page",
             `
               import { loadStoryblokBridge } from "@storyblok/astro";
               loadStoryblokBridge().then(() => {
                 const { StoryblokBridge, location } = window;
-                const storyblokInstance = new StoryblokBridge();
+                const storyblokInstance = new StoryblokBridge(${JSON.stringify(
+                  bridgeConfigurationOptions
+                )});
 
                 storyblokInstance.on(["published", "change"], (event) => {
                   if (!event.slugChanged) {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -8,7 +8,7 @@ import {
 } from "@storyblok/js";
 
 import type { AstroIntegration } from "astro";
-import {
+import type {
   ISbConfig,
   ISbRichtext,
   SbRichTextOptions,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -58,7 +58,7 @@ export type IntegrationOptions = {
    */
   apiOptions?: ISbConfig;
   /**
-   * A boolean to enable/disable the Storyblok JavaScript Bridge or a StoryblokBridgeConfigV2 configuration object. Enabled by default.
+   * A boolean to enable/disable the Storyblok JavaScript Bridge or provide a StoryblokBridgeConfigV2 configuration object. Enabled by default.
    */
   bridge?: boolean | StoryblokBridgeConfigV2;
   /**

--- a/playground-test/astro.config.mjs
+++ b/playground-test/astro.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig } from "astro/config";
 import storyblok from "@storyblok/astro";
 import tailwind from "@astrojs/tailwind";
+// import basicSsl from "@vitejs/plugin-basic-ssl";
 
 export default defineConfig({
   integrations: [
@@ -15,9 +16,15 @@ export default defineConfig({
         grid: "storyblok/Grid",
         teaser: "storyblok/Teaser",
         richtext: "storyblok/RichText",
-        embedded_blok: "storyblok/EmbeddedBlok"
+        embedded_blok: "storyblok/EmbeddedBlok",
       },
     }),
     tailwind(),
   ],
+  // vite: {
+  //   plugins: [basicSsl()],
+  //   server: {
+  //     https: true,
+  //   },
+  // },
 });


### PR DESCRIPTION
The purpose of this PR is to let the user be able to pass `StoryblokBridge` options via `astro.config`.

The idea behind it is:
- `resolvedOptions.bridge` should be a `boolean` or an instance of `StoryblokBridgeConfigV2` options
- If a user provides a truthy value, the options are passed to the StoryblokBridge constructor. This means that providing `bridge: true` would behave the same as providing `bridge: { foo: "bar" }`
 
Initially, I tried to cherry-pick only the keys that are part of the `StoryblokBridgeConfigV2` interface from the provided object, to avoid injecting useless (/ potentially harmful) config options to the bridge (i.e. if you provide this object:
```
bridge: { foo: "bar", preventClicks: true }
```
all keys will be merged with the bridge configuration).

In the end, I noticed that there's actually no harm in doing that, plus `JSON.stringify` prevents `eval`-like code injections so I just kept it super straightforward 😄 (And AFAIK there's no easy way to create an array of keys from an interface..).

I also added `basicSsl` to `playground-test` config to be able to try it out in the Storyblok preview, but I commented it out for the sake of existing e2e tests and their configuration which points to `http://localhost:3000`.

As for testing, I tried to set up an e2e test to check for the `preventClicks` option but this behaviour depends heavily on the Storyblok Bridge implementation. Namely, the page has to be in an iframe in order to be able to receive postMessages, plus there's quite some logic in the [Bridge init](https://github.com/storyblok/storyblok-bridge/blob/6b9007507b0ad549fc9d5cfaf673d27d290edbe3/src/bridge-private.js#L169) that's pretty hard to mock. I tested it manually from the Storyblok editor directly and it worked out.