### PR TITLE
Fix: no components error handling

### DIFF
--- a/lib/vite-plugin-storyblok-components.ts
+++ b/lib/vite-plugin-storyblok-components.ts
@@ -99,10 +99,25 @@ export function vitePluginStoryblokComponents(
           }
         }
 
-        return `${imports.join(";")};export default {${Object.keys(components)
-          .filter((key) => !excludedKeys.includes(key))
-          .map((key) => camelcase(key))
-          .join(",")}${fallbackComponentKey}}`;
+        if (!Object.values(components).length) {
+          /**
+           * If no components are registered in astro.config.mjs, either export just the fallback component (default or custom),
+           * or throw an error.
+           */
+          if (enableFallbackComponent) {
+            return `${
+              imports[0]
+            } export default {${fallbackComponentKey.replace(",", "")}}`;
+          }
+          throw new Error(
+            `Currently, no Storyblok components are registered in astro.config.mjs.\nPlease register your components or enable the fallback component.\nDetailed information can be found here: https://github.com/storyblok/storyblok-astro`
+          );
+        } else {
+          return `${imports.join(";")};export default {${Object.keys(components)
+            .filter((key) => !excludedKeys.includes(key))
+            .map((key) => camelcase(key))
+            .join(",")}${fallbackComponentKey}}`;
+        }
       }
     },
   };


### PR DESCRIPTION
This PR addresses the scenario that no Storyblok components are registered in the Astro configuration.
In this scenario, two cases can occur:

- The (default or custom) fallback component is enabled. In this case, the export from the virtual module has to be handled differently.
- The fallback component is disabled (default case). In this case, an error gets thrown, indicating the need to either register Storyblok components or enable the fall component.

Both cases are now handled in the virtual module.