### PR TITLE
Fix blok.component type error when blok.component is undefined.

### DIFF
--- a/lib/StoryblokComponent.astro
+++ b/lib/StoryblokComponent.astro
@@ -21,7 +21,11 @@ if (!blok) {
 /**
  * convert blok components to camel case to match vite-plugin-storyblok-components
  */
-let key = camelcase(blok.component);
+let key = camelcase(blok.component ?? (() => {
+  throw new Error(
+      `Component could not be found for blok "${blok.component}"! 'blok.component' is null or undefined.`
+    )
+})());
 
 const componentFound: boolean = key in components;
 


### PR DESCRIPTION
Not sure if this is the favored solution, but I get a type error here in my dist, along with type errors from the virtual imports from options and components.

Let me know if there's a better way to reason about this and I can make the according changes!