### PR TITLE
Update `peerDependency` range to support Astro 4

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -59,7 +59,7 @@
     "vite-plugin-dts": "^3.6.3"
   },
   "peerDependencies": {
-    "astro": "^2.0.0 || ^3.0.0"
+    "astro": "^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
👋 Hey folks! Just a quick PR to update the `peerDependencies` range to support Astro >4.0.0!

Fixes #583