### PR TITLE
fix: update deprecated appDevOverlayPlugin to addDevToolbarApp

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -105,7 +105,7 @@ export default function storyblokIntegration(
       "astro:config:setup": ({
         injectScript,
         updateConfig,
-        addDevOverlayPlugin,
+        addDevToolbarApp,
       }) => {
         updateConfig({
           vite: {
@@ -164,7 +164,7 @@ export default function storyblokIntegration(
           );
         }
 
-        addDevOverlayPlugin("@storyblok/astro/toolbar-app-storyblok.ts");
+        addDevToolbarApp("@storyblok/astro/toolbar-app-storyblok.ts");
       },
     },
   };


### PR DESCRIPTION
Followed [Astro docs](https://docs.astro.build/en/reference/dev-toolbar-app-reference/#adding-apps) for updating deprecated method name for Dev Toolbar.