### PR TITLE
fix: live preview bug fix

### DIFF
--- a/lib/live-preview/middleware.ts
+++ b/lib/live-preview/middleware.ts
@@ -2,9 +2,22 @@ import { defineMiddleware } from "astro/middleware";
 
 export const onRequest = defineMiddleware(async ({ locals, request }, next) => {
   if (request["method"] === "POST") {
-    const requestBody = await request.json();
-    if (requestBody && requestBody["is_storyblok_preview"]) {
-      locals["_storyblok_preview_data"] = requestBody;
+    const url = new URL(request.url);
+    //First do a basic check if its coming from within storyblok
+    const isStoryblokRequest =
+      url.searchParams.has("_storyblok") &&
+      url.searchParams.has("_storyblok_c");
+
+    if (isStoryblokRequest) {
+      try {
+        //Create a copy of the request
+        const requestBody = await request.clone().json();
+        if (requestBody && requestBody["is_storyblok_preview"]) {
+          locals["_storyblok_preview_data"] = requestBody;
+        }
+      } catch (error) {
+        console.error("Error reading request body:", error);
+      }
     }
   }
   return next();

--- a/playground-ssr/.astro/settings.json
+++ b/playground-ssr/.astro/settings.json
@@ -1,0 +1,5 @@
+{
+	"_variables": {
+		"lastUpdateCheck": 1720535052198
+	}
+}

--- a/playground-ssr/src/pages/api/test.ts
+++ b/playground-ssr/src/pages/api/test.ts
@@ -1,0 +1,16 @@
+import type { APIRoute } from "astro";
+
+export const GET: APIRoute = ({ request }) => {
+  return new Response(
+    JSON.stringify({
+      path: new URL(request.url).pathname,
+    })
+  );
+};
+export const POST: APIRoute = async ({ request }) => {
+  return new Response(
+    JSON.stringify({
+      body: await request.json(),
+    })
+  );
+};

--- a/playground/.astro/settings.json
+++ b/playground/.astro/settings.json
@@ -1,0 +1,5 @@
+{
+	"_variables": {
+		"lastUpdateCheck": 1720535044084
+	}
+}


### PR DESCRIPTION
- Refactored middleware to check if POST requests are coming from Storyblok by parsing the URL.
- Made a copy of the request body in the middleware, allowing it to be read in other API endpoints.
- Added error handling for request body parsing.
- Fixes #845