### PR TITLE
fix: suppress richtext warning from js-client

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -51,7 +51,7 @@
     "prepublishOnly": "npm run build && cp ../README.md ./"
   },
   "dependencies": {
-    "@storyblok/js": "^3.0.9",
+    "@storyblok/js": "^3.1.4",
     "camelcase": "^8.0.0",
     "lodash.mergewith": "^4.6.2"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
       "name": "@storyblok/astro",
       "version": "1.0.0",
       "dependencies": {
-        "@storyblok/js": "^3.0.9",
+        "@storyblok/js": "^3.1.4",
         "camelcase": "^8.0.0",
         "lodash.mergewith": "^4.6.2"
       },
@@ -3396,11 +3396,20 @@
       "link": true
     },
     "node_modules/@storyblok/js": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@storyblok/js/-/js-3.0.9.tgz",
-      "integrity": "sha512-Rgh3SeK5fIzSgPXYgRk103yAgZyU4tJYBxVHq8WTH84n04ubcS54WO6mV/eyP5LX6hfLzOrjcAtizGPKteomcg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@storyblok/js/-/js-3.1.4.tgz",
+      "integrity": "sha512-Uh+ESR4xF+8C7veSiVA3IeYNqPdwRDOxJdqyGHAVBZ7OuQ2SzZkW3eAKax2TiX8W4DPSljIKvI6MKpvEG3KwWA==",
       "dependencies": {
-        "storyblok-js-client": "^6.8.3"
+        "@storyblok/richtext": "^2.0.0",
+        "storyblok-js-client": "^6.9.2"
+      }
+    },
+    "node_modules/@storyblok/richtext": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@storyblok/richtext/-/richtext-2.0.0.tgz",
+      "integrity": "sha512-yJm5BgWrCRGUdwZtviPgGno3rLXcnEvjK1bL1Ut4GmU1UOEVLC42m543EtrrOBVGDZdRPD9dK8ObgyHp6zNwqw==",
+      "dependencies": {
+        "consola": "^3.2.3"
       }
     },
     "node_modules/@sveltejs/vite-plugin-svelte": {
@@ -5938,6 +5947,14 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/consola": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.2.3.tgz",
+      "integrity": "sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ==",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
     },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
@@ -12631,9 +12648,9 @@
       }
     },
     "node_modules/storyblok-js-client": {
-      "version": "6.8.3",
-      "resolved": "https://registry.npmjs.org/storyblok-js-client/-/storyblok-js-client-6.8.3.tgz",
-      "integrity": "sha512-199ULvMM4Lm0B1SrTr0QTUgtftV0OPePA4T0uJXq9nKyFFS8ln3cdVS6iegsh89BYlrQCncfRPjufaYBzvvtPg=="
+      "version": "6.9.2",
+      "resolved": "https://registry.npmjs.org/storyblok-js-client/-/storyblok-js-client-6.9.2.tgz",
+      "integrity": "sha512-31GM5X/SIP4eJsSMCpAnaPDRmmUotSSWD3Umnuzf3CGqjyakot2Gv5QmuV23fRM7TCDUQlg5wurROmAzkKMKKg=="
     },
     "node_modules/stream-combiner": {
       "version": "0.0.4",

--- a/playground/.astro/settings.json
+++ b/playground/.astro/settings.json
@@ -1,5 +1,5 @@
 {
 	"_variables": {
-		"lastUpdateCheck": 1720535044084
+		"lastUpdateCheck": 1725528229180
 	}
 }

--- a/playground/.astro/types.d.ts
+++ b/playground/.astro/types.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="astro/client" />

--- a/playground/src/env.d.ts
+++ b/playground/src/env.d.ts
@@ -1,1 +1,2 @@
+/// <reference path="../.astro/types.d.ts" />
 /// <reference types="astro/client" />


### PR DESCRIPTION
Based on user feedback, `renderRichText` was prompting warnings that are not valuable for SDK users. This is the follow up task for https://github.com/storyblok/storyblok-js/commit/7a0d6ae0014cfeeeb843bcaabd1f7b02ce4dc918