### PR TITLE
Fix link in README to kickstart a project with Astro

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue.bug.yml
+++ b/.github/ISSUE_TEMPLATE/issue.bug.yml
@@ -60,7 +60,7 @@ body:
       label: Validations
       description: Before submitting the issue, please make sure you do the following
       options:
-        - label: Follow our [Code of Conduct](https://www.storyblok.com/trust-center#code-of-conduct?utm_source=github.com&utm_medium=readme&utm_campaign=storyblok-js-client)
+        - label: Follow our [Code of Conduct](https://www.storyblok.com/trust-center?utm_source=github.com&utm_medium=readme&utm_campaign=storyblok-js-client#code-of-conduct)
           required: true
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/issue.fr.yml
+++ b/.github/ISSUE_TEMPLATE/issue.fr.yml
@@ -32,7 +32,7 @@ body:
       label: Validations
       description: Before submitting the feature request, please make sure you do the following
       options:
-        - label: Follow our [Code of Conduct](https://www.storyblok.com/trust-center#code-of-conduct?utm_source=github.com&utm_medium=readme&utm_campaign=storyblok-js-client)
+        - label: Follow our [Code of Conduct](https://www.storyblok.com/trust-center?utm_source=github.com&utm_medium=readme&utm_campaign=storyblok-js-client#code-of-conduct)
           required: true
   - type: markdown
     attributes:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 ## Kickstart a new project
 
-Are you eager to dive into coding? **[Follow these steps to kickstart a new project with Storyblok and Astro](https://www.storyblok.com/technologies#astro?utm_source=github.com&utm_medium=readme&utm_campaign=storyblok-astro)**, and get started in just a few minutes!
+Are you eager to dive into coding? **[Follow these steps to kickstart a new project with Storyblok and Astro](https://www.storyblok.com/technologies?utm_source=github.com&utm_medium=readme&utm_campaign=storyblok-astro#astro)**, and get started in just a few minutes!
 
 ## Ultimate Tutorial
 

--- a/README.md
+++ b/README.md
@@ -432,5 +432,5 @@ Our heartfelt thanks go to [Virtual Identity](https://www.virtual-identity.com/)
 
 ## Contributing
 
-Please see our [contributing guidelines](https://github.com/storyblok/.github/blob/master/contributing.md) and our [code of conduct](https://www.storyblok.com/trust-center#code-of-conduct?utm_source=github.com&utm_medium=readme&utm_campaign=storyblok-astro).
+Please see our [contributing guidelines](https://github.com/storyblok/.github/blob/master/contributing.md) and our [code of conduct](https://www.storyblok.com/trust-center?utm_source=github.com&utm_medium=readme&utm_campaign=storyblok-astro#code-of-conduct).
 This project uses [semantic-release](https://semantic-release.gitbook.io/semantic-release/) for generating new versions by using commit messages. We use the Angular Convention to name the commits.


### PR DESCRIPTION
I noticed that when I visit the link "Follow these steps to kickstart a new project with Storyblok and Astro", the Astro tab is not preselected. The cause for this is a malformed URL leading to an exception (see screenshot below). Query params in a URL must always come before a hash location, because everything after the `#` is interpreted as part of the hash location, including `?`.

I ran a global search of `(.+)#(.*)\?` on the repo and found a few more website links that needed fixing, all for the code of conduct (`https://www.storyblok.com/trust-center?utm_source=github.com&utm_medium=readme&utm_campaign=storyblok-js-client#code-of-conduct`). However, the hash location `#code-of-conduct` doesn't exist on that page at all, so there might be more problems with that link.

I also found a sign-up link to the app (`https://app.storyblok.com/#!/signup?utm_source=github.com&utm_medium=readme&utm_campaign=storyblok-astro`) but I'm not touching that one. Since the app is a SPA with, I assume, a hash-location based router, the rule of putting query params might not apply.


## Error

```
Uncaught DOMException: Element.querySelector: '#astro?utm_source=github.com&utm_medium=readme&utm_campaign=storyblok-astro' is not a valid selector
    <anonymous> https://www.storyblok.com/_astro/hoisted.PgQtRDpH.js:14
    <anonymous> https://www.storyblok.com/_astro/hoisted.PgQtRDpH.js:14
```
<img width="1215" alt="SCR-20241008-msjo" src="https://github.com/user-attachments/assets/4a775276-836b-4d5c-ba84-97fea6298450">

