### PR TITLE
fix: add `withastro` keyword to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "keywords": [
     "astro",
     "storyblok",
-    "astro-sdk"
+    "astro-sdk",
+    "withastro"
   ],
   "exports": {
     ".": {


### PR DESCRIPTION
208dc61cbfd76b305d16d0fc913766d4552b45e6 updated the keywords of this package to rename `astro-component` to `astro-sdk`, but this caused the package to fall out of Astro’s [integrations catalogue](https://astro.build/integrations) because the catalogue is populated with packages containing one of the keywords `astro-component` or `withastro` (see [Astro’s integration docs](https://docs.astro.build/en/reference/publish-to-npm/#packagejson-data)).

This PR adds the `withastro` keyword to ensure the Storyblok SDK will still show up in Astro’s integration catalogue.