### PR TITLE
fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ const { blok } = Astro.props
 ```
 
 > [!NOTE]  
-> The `blok` is the actual blok data coming from [Storblok's Content Delivery API](https://www.storyblok.com/docs/api/content-delivery/v2?utm_source=github.com&utm_medium=readme&utm_campaign=storyblok-astro).
+> The `blok` is the actual blok data coming from [Storyblok's Content Delivery API](https://www.storyblok.com/docs/api/content-delivery/v2?utm_source=github.com&utm_medium=readme&utm_campaign=storyblok-astro).
 
 #### Using fallback components
 


### PR DESCRIPTION
I just stumbled upon this typo while reading through the documentation: Storyblok was typed as "Storblok"