### PR TITLE
feat!: removed legacy richtext exports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Vitest run
         run: pnpm run test:unit:ci --silent
 
+      - name: Install cypress
+        run: pnpm cypress install
+
       - name: Cypress run
         run: pnpm run test:e2e
 

--- a/README.md
+++ b/README.md
@@ -371,64 +371,17 @@ const renderedRichText = richTextResolver({
 
 To learn more about the new `richTextResolver` API, please refer to the [storyblok-richtext docs](https://github.com/storyblok/richtext).
 
-Similar to the legacy `renderRichText` function, this vanilla approach only supports parsing and returning native HTML tags, if you are not embedding `bloks` in your rich text. Then you can use the [`set:html` directive](https://docs.astro.build/en/reference/directives-reference/#sethtml):
-
-## Legacy Rendering Rich Text
-
-> [!WARNING]  
-> The legacy `richTextResolver` is soon to be deprecated. We recommend migrating to the new approach described above instead.
-
-
-> [!NOTE]  
-> While @storyblok/astro provides basic richtext rendering capabilities, for advanced use cases, it is highly recommended to use [storyblok-rich-text-astro-renderer](https://github.com/NordSecurity/storyblok-rich-text-astro-renderer).
-
-You can easily render rich text by using either the `renderRichText` function included in `@storyblok/astro`.
-Use `renderRichText`, which only supports parsing and returning native HTML tags, if you are not embedding `bloks` in your rich text. Then you can use the [`set:html` directive](https://docs.astro.build/en/reference/directives-reference/#sethtml):
+Or use the `renderRichText` function to render rich text.
 
 ```jsx
 ---
 import { renderRichText } from "@storyblok/astro";
 
-const { blok } = Astro.props
-
-const renderedRichText = renderRichText(blok.text)
+const renderedRichText = renderRichText(data, options);
 ---
 
 <div set:html={renderedRichText}></div>
 ```
-
-You can also set a **custom Schema and component resolver** by passing the options as the second parameter of the `renderRichText` function:
-
-```jsx
-import { RichTextSchema, renderRichText } from "@storyblok/astro";
-import cloneDeep from "clone-deep";
-
-const mySchema = cloneDeep(RichTextSchema); // you can make a copy of the default RichTextSchema
-// ... and edit the nodes and marks, or add your own.
-// Check the base RichTextSchema source here https://github.com/storyblok/storyblok-js-client/blob/v4/source/schema.js
-
-const { blok } = Astro.props;
-
-const renderedRichText = renderRichText(blok.text, {
-  schema: mySchema,
-  resolver: (component, blok) => {
-    switch (component) {
-      case "my-custom-component":
-        return `<div class="my-component-class">${blok.text}</div>`;
-        break;
-      default:
-        return `Component ${component} not found`;
-    }
-  },
-});
-```
-
-### RichTextRenderer `deprecated`
-
-~~Use the `<RichTextRenderer />` component if you are embedding `bloks` in your rich text:~~
-
-> [!IMPORTANT]
-> As of `@storyblok/astro` v5, the `<RichTextRenderer />` component has been removed. Use the `renderRichText` function instead.
 
 ## API
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "astro": "^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "dependencies": {
-    "@storyblok/js": "3.5.0",
+    "@storyblok/js": "4.0.0",
     "camelcase": "^8.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@storyblok/js':
-        specifier: 3.5.0
-        version: 3.5.0
+        specifier: 4.0.0
+        version: 4.0.0
       camelcase:
         specifier: ^8.0.0
         version: 8.0.0
@@ -1350,8 +1350,8 @@ packages:
     peerDependencies:
       eslint: '>=8.40.0'
 
-  '@storyblok/js@3.5.0':
-    resolution: {integrity: sha512-1gGY6t4CIZNOt9t5h+Q7lMN6lfG8VgrChktv1L3gsMzBcOcEnQdr7ZeqUWFbB9VlGPc8X/RRfULRgckzEwJ6BA==}
+  '@storyblok/js@4.0.0':
+    resolution: {integrity: sha512-D3EB9LQ9P9I9WTauwUaBkZ6J8qMVnpUAxPZRbarL7SdDKILD4CAVR9Bn+T6H5znu45J4Zq9P7OvxH+sQZPvgXw==}
 
   '@storyblok/richtext@3.2.0':
     resolution: {integrity: sha512-koVGDv1HtiI5vymE5fzRB1VO1PNguj+RSfHI4zCy2+90pRoqZbsUCR8V2TaNl7Pg8R1oOkFZnbAxdt9Z4xoxDg==}
@@ -4489,8 +4489,8 @@ packages:
   std-env@3.8.0:
     resolution: {integrity: sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==}
 
-  storyblok-js-client@6.11.0:
-    resolution: {integrity: sha512-2uhd/VA51AB88XoqQ+rw9JqkWNoPl2ydg+J49w+2KBqqFvV2EtUhrS2umnabU8sD7HftFsMg0n69EWhkeDyM/A==}
+  storyblok-js-client@7.0.0:
+    resolution: {integrity: sha512-00zWW3jscL4W1kek9QCrInq1jw4xwjeM0jXuKg4sa/bCT8QuLGaGU9Wn3hat/hkvZLRFC09fV4sJRxDqwsFaKQ==}
 
   stream-combiner@0.0.4:
     resolution: {integrity: sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==}
@@ -6455,10 +6455,10 @@ snapshots:
       - typescript
       - vitest
 
-  '@storyblok/js@3.5.0':
+  '@storyblok/js@4.0.0':
     dependencies:
       '@storyblok/richtext': 3.2.0
-      storyblok-js-client: 6.11.0
+      storyblok-js-client: 7.0.0
 
   '@storyblok/richtext@3.2.0': {}
 
@@ -10217,7 +10217,7 @@ snapshots:
 
   std-env@3.8.0: {}
 
-  storyblok-js-client@6.11.0: {}
+  storyblok-js-client@7.0.0: {}
 
   stream-combiner@0.0.4:
     dependencies:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,23 +1,14 @@
 import storyblokIntegration from './lib/storyblok-integration';
 
-export { getLiveStory, renderRichText, useStoryblokApi } from './lib/helpers';
+export { getLiveStory, useStoryblokApi } from './lib/helpers';
 export { handleStoryblokMessage } from './live-preview/handleStoryblokMessage';
 export * from './types';
 export { toCamelCase } from './utils/toCamelCase';
 export {
   loadStoryblokBridge,
-  RichTextResolver,
+  renderRichText,
   // New richtext
   richTextResolver,
-  RichTextSchema,
   storyblokEditable,
-  type StoryblokRichTextDocumentNode,
-  type StoryblokRichTextImageOptimizationOptions,
-  type StoryblokRichTextNode,
-  type StoryblokRichTextNodeResolver,
-  type StoryblokRichTextNodeTypes,
-  type StoryblokRichTextOptions,
-  type StoryblokRichTextResolvers,
-  TextTypes,
 } from '@storyblok/js';
 export { storyblokIntegration as storyblok };

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,13 +1,9 @@
 import type {
-  ISbRichtext,
   ISbStoryData,
-  RichTextResolver,
-  SbRichTextOptions,
   StoryblokBridgeConfigV2,
   StoryblokClient,
 } from '../types';
 import type { AstroGlobal } from 'astro';
-import { renderRichText as origRenderRichText } from '@storyblok/js';
 
 export function useStoryblokApi(): StoryblokClient {
   if (!globalThis?.storyblokApiInstance) {
@@ -23,20 +19,6 @@ export async function getLiveStory(Astro: Readonly<AstroGlobal>) {
     story = Astro.locals._storyblok_preview_data;
   }
   return story;
-}
-
-export function renderRichText(
-  data?: ISbRichtext,
-  options?: SbRichTextOptions,
-) {
-  const resolverInstance: RichTextResolver | undefined
-    = globalThis?.storyblokApiInstance?.richTextResolver;
-  if (!resolverInstance) {
-    throw new Error(
-      'Please initialize the Storyblok SDK before calling the renderRichText function',
-    );
-  }
-  return origRenderRichText(data, options, resolverInstance);
 }
 
 export function initStoryblokBridge(

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 export type {
   ArrayFn,
   AsyncFn,
+  BlockTypes,
   ISbAlternateObject, // previously AlternateObject
   ISbCache, // previously StoryblokCache
   ISbConfig, // previously StoryblokConfig
@@ -9,24 +10,29 @@ export type {
   ISbError,
   ISbEventPayload,
   ISbManagmentApiResult, // previously StoryblokManagmentApiResult
-  ISbNode,
   ISbResponse,
   ISbResult, // previously StoryblokResult
-  ISbRichtext, // previously Richtext
   ISbSchema,
   ISbStories, // previously Stories
   ISbStoriesParams, // previously StoriesParams
   ISbStory, // previously Story
   ISbStoryData, // previously StoryData
   ISbStoryParams, // previously StoryParams
-  RichTextResolver,
+  MarkTypes,
   SbBlokData,
   SbBlokKeyDataTypes,
   SbPluginFactory,
-  SbRichTextOptions,
   SbSDKOptions,
   StoryblokBridgeConfigV2,
   StoryblokBridgeV2,
   StoryblokClient,
   StoryblokComponentType,
+  StoryblokRichTextDocumentNode,
+  StoryblokRichTextImageOptimizationOptions,
+  StoryblokRichTextNode,
+  StoryblokRichTextNodeResolver,
+  StoryblokRichTextNodeTypes,
+  StoryblokRichTextOptions,
+  StoryblokRichTextResolvers,
+  TextTypes,
 } from '@storyblok/js';


### PR DESCRIPTION
- Updated @storyblok/js from 3.5.0 to 4.0.0
- Updated storyblok-js-client from 6.11.0 to 7.0.0
- Removed deprecated `renderRichText` function and related types from exports
- Added new types for rich text handling from @storyblok/js